### PR TITLE
Add DescriptionSubtitle Component

### DIFF
--- a/src/styles/main.js
+++ b/src/styles/main.js
@@ -129,3 +129,14 @@ export const DescriptionText = styled.li`
 		margin-top: 3px;
 	}
 `;
+
+export const DescriptionSubtitle = styled.li`
+	color: ${(props) => props.theme.subtitleColor};
+	font-size: 14px;
+	font-style: italic;
+	font-weight: 400;
+
+	&:not(:first-of-type) {
+		margin-top: 10px;
+	}
+`;


### PR DESCRIPTION
The Subtitle Component is not a list item.
Lighthouse throws an error if there is another item in a list.
This adds a new component that solves the issue.